### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 2. Always give credit to the original work creator and if any, the modifications creators.
 
   2a. Must follow the following form or similar:
-    - "Original work by <orignal work creator> at <link>" or "Original work by <orignal work creator> at <link> and modified from <modifications creator>'s modifications at <link>"
+    - "Original work by <original work creator> at <link>" or "Original work by <original work creator> at <link> and modified from <modifications creator>'s modifications at <link>"
 
 3. If your modification becomes more popular than the original work, consider bringing your modifications to the original work creator and proposing a potential merge.
 
@@ -29,5 +29,5 @@ TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
   4a. If the software is broken/malfunctions, fix it.
   4b. If the software is broken/malfunctions, do not complain, bring it to the attention of the creator of the specific code.
 
-Report issues or typos with this licence at frenchbones@outlook.com
+Report issues or typos with this license at frenchbones@outlook.com
 License GitHub: https://github.com/frenchbones/fb-fair-license


### PR DESCRIPTION
 - Inconsistent spelling of "license" with both British & American.
 - Small fix for other mistakes such as "orignal" -> "original"